### PR TITLE
Admin edits company info

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -1,9 +1,34 @@
 class Admin::CompaniesController < ApplicationController
+  before_action :verify_admin
+  
   def edit
     @company = Company.find(params[:id])
   end
 
   def update
-    byebug
+    company = Company.find(params[:id])
+    if company.update(company_params)
+      flash[:notice] = "Company information updated."
+      redirect_to company_path(company)
+    else
+      flash.now[:danger] = company.errors.full_messages
+      render :edit
+    end
   end
+
+  private
+    def company_params
+      params.require(:company).permit(:name,
+                                      :street_address,
+                                      :city_state_zip,
+                                      :phone,
+                                      :website,
+                                      :headquarters,
+                                      :products_services,
+                                      :person_in_charge,
+                                      :city_id,
+                                      :state_id,
+                                      :category_id,
+                                      :zip_code_id)
+    end
 end

--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -1,0 +1,9 @@
+class Admin::CompaniesController < ApplicationController
+  def edit
+    @company = Company.find(params[:id])
+  end
+
+  def update
+    byebug
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,12 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
+  def verify_admin
+    unless current_user.admin?
+      render file: "/public/404", status: 404, layout: false
+    end
+  end
+
   private
     def authorize!
       unless authorized?

--- a/app/views/admin/companies/edit.html.erb
+++ b/app/views/admin/companies/edit.html.erb
@@ -1,0 +1,40 @@
+<%= form_for @company, url: admin_company_path(@company) do |f| %>
+  <%= f.label :name   %>
+  <%= f.text_field :name %>
+
+  <%= f.label :street_address %>
+  <%= f.text_field :street_address %>
+
+  <%= f.label :city_state_zip %>
+  <%= f.text_field :city_state_zip %>
+
+  <%= f.label :city %>
+  <%= f.collection_select :city_id, City.all, :id,:name %>
+
+  <%= f.label :category %>
+  <%= f.collection_select :category_id, Category.all, :id,:name %>
+
+  <%= f.label :state %>
+  <%= f.collection_select :state_id, State.all, :id,:name %>
+
+  <%= f.label :zip_code %>
+  <%= f.collection_select :zip_code_id, ZipCode.all, :id,:zip_code %>
+
+  <%= f.label :phone %>
+  <%= f.text_field :phone %>
+
+  <%= f.label :website %>
+  <%= f.text_field :website %>
+
+  <%= f.label :headquarters %>
+  <%= f.text_field :headquarters %>
+
+  <%= f.label :products_services %>
+  <%= f.text_field :products_services %>
+
+  <%= f.label :person_in_charge %>
+  <%= f.text_field :person_in_charge %>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -36,6 +36,13 @@
   <% end %>
 <% end %>
 
+<% if current_user.admin? %>
+  <h4>Administrator Tools</h4>
+  <ul>
+    <li><%= link_to 'Edit Information', edit_admin_company_path(@company) %></li>
+  </ul>
+<% end %>
+
 <h3>Notes</h3>
 <div id='notes' class='panel-group'>
 <% @company.notes.each do |note| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,8 @@ Rails.application.routes.draw do
 
   resources :cities,            only: [:index, :show]
   resources :starred_companies, only: [:index, :create, :destroy]
+
+  namespace :admin do
+    resources :companies,       only: [:edit, :update]
+  end
 end

--- a/spec/features/admin_edits_company_info_spec.rb
+++ b/spec/features/admin_edits_company_info_spec.rb
@@ -10,6 +10,6 @@ RSpec.feature 'admin edits company information' do
     click_on 'Update Company'
 
     expect(page).to have_content('Test Edit')
-    expect(page).to_not have_conten(company.name)
+    expect(page).to_not have_content(company.name)
   end
 end

--- a/spec/features/admin_edits_company_info_spec.rb
+++ b/spec/features/admin_edits_company_info_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'admin edits company information' do
+  it 'clicks edit button on company page and changes information' do
+    company = create(:company)
+    admin_logs_in
+    visit company_path(company)
+    click_on 'Edit Information'
+    fill_in 'company_name', with: 'Test Edit'
+    click_on 'Update Company'
+
+    expect(page).to have_content('Test Edit')
+    expect(page).to_not have_conten(company.name)
+  end
+end


### PR DESCRIPTION
Admin now sees a link to edit company information on a company show page.

Admin is able to fill out a form and change any information and is redirected to that company's show page.