### PR TITLE
Na admin edit and delete notes spec

### DIFF
--- a/spec/features/admin_deletes_company_note_spec.rb
+++ b/spec/features/admin_deletes_company_note_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'admin deletes company note' do
+  it 'clicks delete note button on company page' do
+    create_note_with_company_and_user
+    admin_logs_in
+    
+    visit company_path(Company.last)
+    
+    expect(page).to have_content('Solid Company')
+    expect(page).to have_content('They are solid.')
+  
+    within "#notes" do
+      first('.delete-button').click
+    end
+    expect(page).to_not have_content('Solid Company')
+    expect(page).to_not have_content('They are solid.')
+  end
+end

--- a/spec/features/admin_edits_company_note_spec.rb
+++ b/spec/features/admin_edits_company_note_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature 'admin edits company note' do
+  it 'clicks edit note button on company page and edits note' do
+    create_note_with_company_and_user
+    admin_logs_in
+    
+    visit company_path(Company.last)
+    
+    expect(page).to have_content('Solid Company')
+    expect(page).to have_content('They are solid.')
+  
+    within "#notes" do
+      first('.edit-button').click
+    end
+    fill_in 'note_title', with: 'New Title'
+    fill_in 'note_body', with: 'New Body'
+    click_on "Update Note"
+    expect(page).to have_content('New Title')
+    expect(page).to have_content('New Body')
+    expect(page).not_to have_content('Solid Company')
+    expect(page).not_to have_content('They are solid.')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,3 +96,18 @@ def add_approved_location_to_company(company)
     status: 1
   )
 end
+
+def create_note_with_company_and_user
+  user = User.create({username: 'tester', slack_uid: 'tester', slack_access_token: 1})
+  company = Company.create({
+      name: "Monocle",
+      website: "www.monocle.com",
+      headquarters: "Denver, CO",
+      products_services: "Jobs"
+    })
+  note = Note.create({
+      title: "Solid Company", 
+      body: "They are solid.", 
+      user_id: user.id, 
+      company_id:  company.id })
+end


### PR DESCRIPTION
@susiirwin @rdavid1099 @brendandillon @danbroadbent Tests for admin can delete and edit note are passing. The two hanging failures are still present from earlier tests.