### PR TITLE
Add logo to company strong params

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -34,7 +34,8 @@ class CompaniesController < ApplicationController
     params.require(:company).permit(:name,
                                     :website,
                                     :headquarters,
-                                    :products_services)
+                                    :products_services,
+                                    :logo)
   end
 
   def company_size


### PR DESCRIPTION
This branch fixes a bug that was causing all logos to go to the default